### PR TITLE
Embeddings API CLI Option

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,11 +1,26 @@
 package app
 
 import (
+	"bufio"
+	"bytes"
 	"cody-gateway-cli/config"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"strings"
 )
+
+type EmbeddingsResponse struct {
+	Embeddings []struct {
+		Index int       `json:"index"`
+		Data  []float64 `json:"data"`
+	} `json:"embeddings"`
+	Model      string `json:"model"`
+	Dimensions int    `json:"dimensions"`
+}
 
 // write a function to make HTTP Get request
 func MakeGetRequest(url string) (response string, err error) {
@@ -70,22 +85,93 @@ func HealthCheck(host string, debugSecretToken string) (ok bool, err error) {
 	return false, nil
 }
 
+// write a function that accepts string array, host, access token to call v1/embeddings API
+func EmbeddingsAPI(terms []string, host string, accessToken string) (embeddingResponse EmbeddingsResponse, err error) {
+	var embeddingsResponse EmbeddingsResponse
+
+	url := fmt.Sprintf("%s/v1/embeddings", host)
+	jsonData, _ := json.Marshal(&map[string]interface{}{
+		"model": "openai/text-embedding-ada-002",
+		"input": terms,
+	})
+
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("X-Sourcegraph-Feature", "chat_completions")
+
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return embeddingResponse, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		err = errors.New("failed to call embeddings api")
+		return
+	}
+
+	// read the response body
+	body, _ := ioutil.ReadAll(resp.Body)
+	err = json.Unmarshal(body, &embeddingsResponse)
+	if err != nil {
+		// Handle error
+		return embeddingResponse, err
+	}
+	return embeddingsResponse, err
+}
+
 func Run(c config.Config) error {
-	version, err := GetVersionInfo(c.GatewayHost, c.DebugSecretToken)
-	if err != nil {
-		return err
+
+	if c.VersionAPI {
+		version, err := GetVersionInfo(c.GatewayHost, c.DebugSecretToken)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Version: %s\n", version)
+	} else if c.HealthCheckAPI {
+		ok, err := HealthCheck(c.GatewayHost, c.DebugSecretToken)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("health check failed")
+		}
+	} else if c.EmbeddingsAPI {
+
+		fmt.Println("Enter keyphrases to embed ✨ (supports multi-line and type --END-- to terminate input):")
+
+		// get multiline input from user and save it as string
+		// declare string array
+		keyphrases := []string{}
+
+		input := bufio.NewReader(os.Stdin)
+		for {
+			fmt.Print("-> ")
+			line, _ := input.ReadString('\n')
+			// convert CRLF to LF
+			line = strings.Replace(line, "\n", "", -1)
+
+			if strings.Compare("--END--", line) == 0 {
+				// break this for loop
+				break
+			} else {
+				// append text to terms array
+				keyphrases = append(keyphrases, line)
+			}
+		}
+
+		resp, err := EmbeddingsAPI(keyphrases, c.GatewayHost, c.GatewayToken)
+		if err != nil {
+			return err
+		}
+		//TODO: Improve this print as table with colors - allow option to write embeddings to disk
+		// print the output as table resp
+		for _, e := range resp.Embeddings {
+			fmt.Printf("%d\t%v\n", e.Index, e.Data)
+		}
+		fmt.Printf("%s\t%d\t%d\n", resp.Model, resp.Dimensions, len(resp.Embeddings))
 	}
-	fmt.Printf("Version: %s\n", version)
-
-	ok, err := HealthCheck(c.GatewayHost, c.DebugSecretToken)
-
-	if err != nil {
-		return err
-	}
-
-	if !ok {
-		return fmt.Errorf("health check failed")
-	}
-
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,17 @@ type Config struct {
 
 	DebugSecretToken string
 
-	GatewayMode string
+	CompletionMode string
+
+	VersionAPI bool
+
+	HealthCheckAPI bool
+
+	AnthropicCompletionAPI bool
+
+	EmbeddingsAPI bool
+
+	OpenAICompletionAPI bool
 }
 
 // New will return Config populated with pre-defined defaults.

--- a/main.go
+++ b/main.go
@@ -13,11 +13,16 @@ import (
 
 // options are command-line options that are provided by the user.
 type options struct {
-	Verbose          bool   `short:"V" long:"verbose" description:"Enable verbose output"`
-	GatewayHost      string `long:"host" description:"Define an alternate SSH Port" default:"22"`
-	GatewayToken     bool   `long:"accesstoken" description:"Ask for a password to use for cody gateway authentication"`
-	DebugSecretToken string `short:"s" long:"debugtoken" description:"Define a bearer secret token to use" env:"SECRET_TOKEN"`
-	GatewayMode      string `short:"m" long:"mode" description:"Define chat or code completion mode"`
+	Verbose                bool   `short:"V" long:"verbose" description:"Enable verbose output"`
+	GatewayHost            string `long:"host" description:"Define an alternate SSH Port" default:"22"`
+	GatewayToken           bool   `long:"accesstoken" description:"Ask for a password to use for cody gateway authentication"`
+	DebugSecretToken       string `short:"s" long:"debugtoken" description:"Define a bearer secret token to use" env:"SECRET_TOKEN"`
+	CompletionMode         string `short:"m" long:"mode" description:"Define chat or code completion mode"`
+	VersionAPI             bool   `long:"versionapi" description:"Invoke Cody Gateway version api call"`
+	HealthCheckAPI         bool   `long:"healthcheckapi" description:"Invoke Cody Gateway health check api call"`
+	AnthropicCompletionAPI bool   `long:"anthropicapi" description:"Invoke Anthropic Completion API"`
+	EmbeddingsAPI          bool   `long:"embeddingsapi" description:"Invoke Embeddings API call"`
+	OpenAICompletionAPI    bool   `long:"openaiapi" description:"Invoke OpenAI Completions API call"`
 }
 
 func main() {
@@ -33,20 +38,30 @@ func main() {
 	cfg := config.New()
 	cfg.Verbose = opts.Verbose
 	cfg.GatewayHost = opts.GatewayHost
-	if opts.GatewayMode != "" {
-		cfg.GatewayMode = opts.GatewayMode
-	}
+
 	if opts.DebugSecretToken != "" {
 		cfg.DebugSecretToken = opts.DebugSecretToken
 	}
 
 	if opts.GatewayToken {
-		color.White("Enter Cody Gateway Access Token for %s: ", cfg.GatewayToken)
+		color.White("Enter Cody Gateway Access Token for ")
 		p, err := gopass.GetPasswd()
 		if err != nil {
 			color.Red("Unable to obtain Cody Gateway Access Token: %s", err)
 		}
 		cfg.GatewayToken = string(p)
+	}
+
+	if opts.AnthropicCompletionAPI || opts.OpenAICompletionAPI {
+		if opts.CompletionMode != "" {
+			cfg.CompletionMode = opts.CompletionMode
+		} else {
+			color.Red("Require --mode chat | code when calling Anthropic or OpenAI APIs")
+		}
+	}
+
+	if opts.EmbeddingsAPI {
+		cfg.EmbeddingsAPI = opts.EmbeddingsAPI
 	}
 
 	// Run the App


### PR DESCRIPTION
This PR adds the ability to call the Embeddings API from the Cody Gateway CLI. It does the following:

- Defines an `EmbeddingsResponse` struct to unmarshal the JSON response 
- Implements an `EmbeddingsAPI()` function that accepts an array of terms, host URL and access token
- Constructs a request to the `/v1/embeddings` endpoint with the terms, access token and `chat_completions` feature flag
- Unmarshals the JSON response into the `EmbeddingsResponse` struct
- Returns the `EmbeddingsResponse` and any errors from the API call

This allows the CLI to get embedding vectors from the Cody Gateway for use in other features like chat completions.
